### PR TITLE
#30 Migrate to Eclipse 2021-06

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent { label 'migration' }
   tools {
         maven 'apache-maven-latest'
-        jdk 'oracle-jdk8-latest'
+        jdk 'openjdk-jdk11-latest'
   }
   parameters {
     string(name: 'CORE_BRANCH', defaultValue: 'master', description: 'When build is not triggered by diffmerge-core build, set the branch of diffmerge-core')

--- a/core/examples/apa/org.eclipse.emf.diffmerge.bridge.capella.integration/META-INF/MANIFEST.MF
+++ b/core/examples/apa/org.eclipse.emf.diffmerge.bridge.capella.integration/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.emf.diffmerge.bridge.interactive,
  org.polarsys.capella.core.model.skeleton;bundle-version="1.4.0",
  org.polarsys.capella.core.model.handler;bundle-version="1.4.0"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.bridge.capella.integration,
  org.eclipse.emf.diffmerge.bridge.capella.integration.policies,
  org.eclipse.emf.diffmerge.bridge.capella.integration.scopes,

--- a/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.gen.edit/META-INF/MANIFEST.MF
+++ b/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.gen.edit/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 0.14.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.bridge.examples.apa.provider
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge.bridge.examples.apa.gen;visibility:=reexport,

--- a/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.gen.editor/META-INF/MANIFEST.MF
+++ b/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.gen.editor/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.diffmerge.bridge.examples.apa.presentation.ApaEditorPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.bridge.examples.apa.presentation
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;visibility:=reexport,

--- a/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.gen/META-INF/MANIFEST.MF
+++ b/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.gen/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 0.14.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.bridge.examples.apa,
  org.eclipse.emf.diffmerge.bridge.examples.apa.impl,
  org.eclipse.emf.diffmerge.bridge.examples.apa.util

--- a/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa/META-INF/MANIFEST.MF
+++ b/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa/META-INF/MANIFEST.MF
@@ -14,6 +14,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.diffmerge.bridge.examples.apa.gen,
  org.eclipse.emf.diffmerge.bridge.interactive,
  org.eclipse.emf.diffmerge.bridge.mapping
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.emf.diffmerge.bridge.examples.apa

--- a/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa2capella/META-INF/MANIFEST.MF
+++ b/core/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa2capella/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.diffmerge.bridge.mapping,
  org.eclipse.emf.diffmerge.bridge.examples.apa.gen,
  org.eclipse.emf.diffmerge.bridge.capella.integration
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.diffmerge.bridge.examples.apa2capella,
  org.eclipse.emf.diffmerge.bridge.examples.apa2capella.util

--- a/core/examples/uml/org.eclipse.emf.diffmerge.bridge.examples.uml.modular/META-INF/MANIFEST.MF
+++ b/core/examples/uml/org.eclipse.emf.diffmerge.bridge.examples.uml.modular/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.diffmerge.bridge.uml,
  org.polarsys.capella.core.compare,
  org.eclipse.uml2.uml
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Name: %pluginName
 Automatic-Module-Name: org.eclipse.emf.diffmerge.bridge.examples.uml.modular

--- a/core/plugins/org.eclipse.emf.diffmerge.bridge.incremental/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.bridge.incremental/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.eclipse.emf.diffmerge.bridge.incremental.IncrementalBridge
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge.bridge;visibility:=reexport,
  org.eclipse.emf.diffmerge.bridge.traces.gen;visibility:=reexport
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.emf.diffmerge.bridge.incremental

--- a/core/plugins/org.eclipse.emf.diffmerge.bridge.interactive/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.bridge.interactive/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.emf.diffmerge.ui;visibility:=reexport,
  org.eclipse.emf.diffmerge.bridge.incremental;visibility:=reexport
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.emf.diffmerge.bridge.interactive,

--- a/core/plugins/org.eclipse.emf.diffmerge.bridge.log4j/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.bridge.log4j/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.diffmerge.bridge.log4j;singleton:=true
 Bundle-Version: 0.14.0.qualifier
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %providerName
 Bundle-ClassPath: .
 Export-Package: org.eclipse.emf.diffmerge.bridge.log4j

--- a/core/plugins/org.eclipse.emf.diffmerge.bridge.mapping/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.bridge.mapping/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 0.14.0.qualifier
 Bundle-Activator: org.eclipse.emf.diffmerge.bridge.mapping.MappingBridgePlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge.bridge;visibility:=reexport
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.emf.diffmerge.bridge.mapping,

--- a/core/plugins/org.eclipse.emf.diffmerge.bridge.traces.gen.edit/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.bridge.traces.gen.edit/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.diffmerge.bridge.traces.gen.bridgetraces.provider.BridgeTracesEditPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.bridge.traces.gen.bridgetraces.provider
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.edit;visibility:=reexport,

--- a/core/plugins/org.eclipse.emf.diffmerge.bridge.traces.gen.editor/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.bridge.traces.gen.editor/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.diffmerge.bridge.traces.gen.bridgetraces.presentation.BridgeTracesEditorPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.bridge.traces.gen.bridgetraces.presentation
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;visibility:=reexport,

--- a/core/plugins/org.eclipse.emf.diffmerge.bridge.traces.gen/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.bridge.traces.gen/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 0.14.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.bridge.traces.gen.bridgetraces,
  org.eclipse.emf.diffmerge.bridge.traces.gen.bridgetraces.impl,
  org.eclipse.emf.diffmerge.bridge.traces.gen.bridgetraces.util

--- a/core/plugins/org.eclipse.emf.diffmerge.bridge.uml/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.bridge.uml/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge.gmf;visibility:=reexport,
  org.eclipse.uml2.uml;visibility:=reexport,
  org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.emf.diffmerge.bridge.uml,

--- a/core/plugins/org.eclipse.emf.diffmerge.bridge/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.bridge/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.eclipse.emf.diffmerge.bridge.BridgePlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge;visibility:=reexport,
  org.eclipse.emf.ecore.xmi
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.emf.diffmerge.bridge,

--- a/integrations/transposer/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.transposer.integrated/META-INF/MANIFEST.MF
+++ b/integrations/transposer/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.transposer.integrated/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.diffmerge.bridge.examples.apa.transposer,
  org.eclipse.emf.diffmerge.bridge.integration.transposer,
  org.eclipse.emf.diffmerge.bridge.interactive
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.diffmerge.bridge.examples.apa.transposer.integrated
 Automatic-Module-Name: org.eclipse.emf.diffmerge.bridge.examples.apa.transposer.integrated

--- a/integrations/transposer/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.transposer/META-INF/MANIFEST.MF
+++ b/integrations/transposer/examples/apa/org.eclipse.emf.diffmerge.bridge.examples.apa.transposer/META-INF/MANIFEST.MF
@@ -11,6 +11,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.diffmerge.bridge.examples.apa.gen;visibility:=reexport,
  org.polarsys.kitalpha.transposer.transformation.emf,
  org.polarsys.kitalpha.transposer.emf.toolbox
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.emf.diffmerge.bridge.examples.apa.transposer

--- a/integrations/transposer/plugins/org.eclipse.emf.diffmerge.bridge.integration.transposer/META-INF/MANIFEST.MF
+++ b/integrations/transposer/plugins/org.eclipse.emf.diffmerge.bridge.integration.transposer/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge.bridge;visibility:=reexport,
  org.polarsys.kitalpha.transposer.transformation.emf;visibility:=reexport
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Name: %pluginName
 Export-Package: org.eclipse.emf.diffmerge.bridge.integration.transposer

--- a/releng/org.eclipse.emf.diffmerge.coevolution.configuration/pom.xml
+++ b/releng/org.eclipse.emf.diffmerge.coevolution.configuration/pom.xml
@@ -6,13 +6,13 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<cbi.jarsigner.version>1.1.3</cbi.jarsigner.version>
+		<cbi.jarsigner.version>1.3.2</cbi.jarsigner.version>
 		<core.repo.url>https://ci.eclipse.org/diffmerge/job/emf-diffmerge-core-generic/lastSuccessfulBuild/artifact/releng/org.eclipse.emf.diffmerge.update/target/repository/</core.repo.url>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tycho.version>1.7.0</tycho.version>
+		<tycho.version>2.0.0</tycho.version>
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 	</properties>
 
@@ -122,19 +122,6 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-pack200a-plugin</artifactId>
-						<version>${tycho.version}</version>
-						<executions>
-							<execution>
-								<id>pack200-normalize</id>
-								<goals>
-									<goal>normalize</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
 						<version>${cbi.jarsigner.version}</version>
@@ -145,19 +132,6 @@
 									<goal>sign</goal>
 								</goals>
 								<phase>verify</phase>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-pack200b-plugin</artifactId>
-						<version>${tycho.version}</version>
-						<executions>
-							<execution>
-								<id>pack200-pack</id>
-								<goals>
-									<goal>pack</goal>
-								</goals>
 							</execution>
 						</executions>
 					</plugin>

--- a/releng/org.eclipse.emf.diffmerge.coevolution.configuration/toolchains-hipp.xml
+++ b/releng/org.eclipse.emf.diffmerge.coevolution.configuration/toolchains-hipp.xml
@@ -2,6 +2,15 @@
   <toolchain>
     <type>jdk</type>
     <provides>
+      <id>JavaSE-11</id>
+    </provides>
+    <configuration>
+      <jdkHome>/opt/tools/java/openjdk/jdk-11/latest</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
       <id>JavaSE-1.8</id>
     </provides>
     <configuration>

--- a/releng/org.eclipse.emf.diffmerge.coevolution.javadoc/META-INF/MANIFEST.MF
+++ b/releng/org.eclipse.emf.diffmerge.coevolution.javadoc/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Javadoc for Co-Evolution Core (Incubation)
 Bundle-SymbolicName: org.eclipse.emf.diffmerge.coevolution.javadoc
 Bundle-Version: 0.14.0.qualifier
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.emf.diffmerge.coevolution.javadoc

--- a/releng/org.eclipse.emf.diffmerge.coevolution.target/org.eclipse.emf.diffmerge.coevolution.target.target
+++ b/releng/org.eclipse.emf.diffmerge.coevolution.target/org.eclipse.emf.diffmerge.coevolution.target.target
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="org.eclipse.emf.diffmerge.coevolution" sequenceNumber="1581954752">
+<target name="org.eclipse.emf.diffmerge.coevolution" sequenceNumber="1628519528">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
-      <repository location="http://download.eclipse.org/cbi/updates/license/"/>
+      <repository location="https://download.eclipse.org/cbi/updates/license/"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>
+      <unit id="org.apache.commons.lang" version="0.0.0"/>
       <unit id="org.apache.log4j" version="0.0.0"/>
       <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.platform.sdk" version="0.0.0"/>
@@ -31,11 +32,7 @@
       <unit id="org.eclipse.sirius.runtime.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.sirius.runtime.ide.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.uml2.sdk.feature.group" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/releases/2020-06"/>
-    </location>
-    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.commons.lang" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180330011457/repository/"/>
+      <repository location="https://download.eclipse.org/releases/2021-06"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.polarsys.kitalpha.ad.metadata.feature.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.emf.diffmerge.coevolution.target/org.eclipse.emf.diffmerge.coevolution.target.tpd
+++ b/releng/org.eclipse.emf.diffmerge.coevolution.target/org.eclipse.emf.diffmerge.coevolution.target.tpd
@@ -1,12 +1,13 @@
 target "org.eclipse.emf.diffmerge.coevolution"
 
-location "http://download.eclipse.org/cbi/updates/license/" {
+location "https://download.eclipse.org/cbi/updates/license/" {
 	org.eclipse.license.feature.group [2.0.2.v20181016-2210,2.0.2.v20181016-2210]
 }
 
-location "http://download.eclipse.org/releases/2020-06" {
+location "https://download.eclipse.org/releases/2021-06" {
 	com.google.guava lazy
 	org.apache.log4j lazy
+	org.apache.commons.lang lazy
 	org.eclipse.equinox.executable.feature.group lazy
   	org.eclipse.platform.sdk lazy
   	org.eclipse.jdt.feature.group lazy
@@ -28,10 +29,6 @@ location "http://download.eclipse.org/releases/2020-06" {
 	org.eclipse.sirius.runtime.feature.group lazy
 	org.eclipse.sirius.runtime.ide.ui.feature.group lazy
 	org.eclipse.uml2.sdk.feature.group lazy
-}
-
-location "http://download.eclipse.org/tools/orbit/downloads/drops/R20180330011457/repository/" {
-	org.apache.commons.lang lazy
 }
 
 location "https://download.eclipse.org/kitalpha/updates/release/runtime/1.4.0/" {


### PR DESCRIPTION
- Update TP
- Tycho 2.0.0
- Explicit Java 11 (toolchains and MANIFESTs)
- Remove use of pack200
- Update eclipse-jarsigner-plugin to 1.3.2 (see #31)

Change-Id: I98f93a6b1e9770378d8dcc767ee32e595d088b25